### PR TITLE
Use safe Dotenv loading

### DIFF
--- a/connection.php
+++ b/connection.php
@@ -5,7 +5,7 @@ require_once __DIR__ . '/vendor/autoload.php';
 
 // Load environment variables from the .env file.
 $dotenv = Dotenv\Dotenv::createImmutable(__DIR__);
-$dotenv->load();
+$dotenv->safeLoad();
 
 // Set the default timezone for the application.
 date_default_timezone_set('Asia/Dubai');

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -19,7 +19,7 @@ class IntegrationTest extends TestCase
         // The Dotenv library will automatically load .env if it exists,
         // and environment variables set in phpunit.xml will override it.
         $dotenv = Dotenv\Dotenv::createImmutable(__DIR__ . '/../');
-        $dotenv->load();
+        $dotenv->safeLoad();
     }
 
     public function testDatabaseConnection()


### PR DESCRIPTION
## Summary
- Allow missing .env by using `safeLoad()` in DB connection
- Use `safeLoad()` in integration test bootstrap

## Testing
- `./vendor/bin/phpunit tests/IntegrationTest.php` *(fails: php_network_getaddresses: getaddrinfo for db failed; cURL error 7: Failed to connect to localhost port 8080)*

------
https://chatgpt.com/codex/tasks/task_e_68ae36be4dac832b8dd24ada9e465a4c