### PR TITLE
Use PHP Qodana linter for license checks

### DIFF
--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,5 +1,5 @@
 version: "1.0"
-linter: jetbrains/qodana-jvm:2025.1
+linter: jetbrains/qodana-php:2025.1
 profile:
   name: qodana.recommended
 include:


### PR DESCRIPTION
## Summary
- fix Qodana configuration to use the PHP linter for license checking

## Testing
- `composer install`
- `./vendor/bin/phpunit` *(fails: php_network_getaddresses for db, cURL error 7)*

------
https://chatgpt.com/codex/tasks/task_e_68ae541597e8832bb89c0a21720fdbc9