### PR TITLE
Use Docker Build Cloud for image publishing

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -45,11 +45,20 @@ jobs:
         with:
           cosign-release: 'v2.2.4'
 
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PAT }}
+
       # Set up BuildKit Docker container builder to be able to build
       # multi-platform images and export cache
       # https://github.com/docker/setup-buildx-action
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: cloud
+          endpoint: "tamer2025/mbhtest-pro"
 
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action


### PR DESCRIPTION
## Summary
- build Docker images in `docker-publish` workflow using Docker Build Cloud

## Testing
- `composer install`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68ae5c7932f0832b9d78a7baa8037b3e