### PR TITLE
Use PHP 8.1 with mysqli and copy application

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,18 @@
-FROM php:8.2-fpm
+FROM php:8.1-fpm
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
     libzip-dev \
     zip \
     unzip \
-    && docker-php-ext-install pdo_mysql zip
+    && docker-php-ext-install pdo_mysql zip mysqli \
+    && docker-php-ext-enable mysqli
 
 # Install Composer
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 
 # Set working directory
 WORKDIR /var/www/html
+
+COPY . /var/www/html
+RUN chown -R www-data:www-data /var/www/html


### PR DESCRIPTION
## Summary
- build PHP container using 8.1-fpm
- install and enable mysqli and copy project into container with proper ownership

## Testing
- `vendor/bin/phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_68ae6058d0a4832bbd6bcbe16d9b68b0