### PR TITLE
fix: resolve undefined variables in legacy PHP scripts

### DIFF
--- a/api/client_add.php
+++ b/api/client_add.php
@@ -5,6 +5,9 @@ include_once '../login_check.php';
 include_once '../permissions_check.php';
 include_once '../AES256.php';
 
+$encryption_key = getenv('ENCRYPTION_KEY') ?: 'default_key';
+$aes = new AES256($encryption_key);
+
 $response = ['status' => 'error', 'message' => 'An unknown error occurred.'];
 
 if ($row_permcheck['clients_aperm'] != 1) {
@@ -14,8 +17,8 @@ if ($row_permcheck['clients_aperm'] != 1) {
 }
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $arname = trim($_POST['arname']);
-    $tel1 = trim($_POST['tel1']);
+    $arname = trim($_POST['arname'] ?? '');
+    $tel1 = trim($_POST['tel1'] ?? '');
     
     if (empty($arname) || empty($tel1)) {
         $response['message'] = 'Required fields are missing.';
@@ -23,17 +26,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         exit();
     }
     
-    $engname = trim($_POST['engname']);
-    $client_kind = trim($_POST['client_kind']);
-    $client_type = trim($_POST['client_type']);
-    $country = trim($_POST['country']);
-    $tel2 = trim($_POST['tel2']);
-    $email = trim($_POST['email']);
-    $fax = trim($_POST['fax']);
-    $address = trim($_POST['address']);
+    $engname = trim($_POST['engname'] ?? '');
+    $client_kind = trim($_POST['client_kind'] ?? '');
+    $client_type = trim($_POST['client_type'] ?? '');
+    $country = trim($_POST['country'] ?? '');
+    $tel2 = trim($_POST['tel2'] ?? '');
+    $email = trim($_POST['email'] ?? '');
+    $fax = trim($_POST['fax'] ?? '');
+    $address = trim($_POST['address'] ?? '');
     
     $password = bin2hex(random_bytes(8));
-    $encrypted_password = openssl_encrypt($password, $cipher, $key, $options, $iv);
+    $encrypted_password = $aes->encrypt($password);
 
     $sql = "INSERT INTO client (arname, engname, client_kind, client_type, country, tel1, tel2, email, fax, address, password, perm) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)";
     $stmt = $conn->prepare($sql);

--- a/api/saveClient.php
+++ b/api/saveClient.php
@@ -4,21 +4,24 @@ include_once '../connection.php';
 include_once '../login_check.php';
 include_once '../AES256.php';
 
+$encryption_key = getenv('ENCRYPTION_KEY') ?: 'default_key';
+$aes = new AES256($encryption_key);
+
 $response = ['status' => 'error', 'message' => 'Invalid request method.'];
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     // --- Data Collection and Sanitization ---
     $client_id = isset($_POST['client_id']) && !empty($_POST['client_id']) ? (int)$_POST['client_id'] : null;
-    $arname = trim($_POST['arname']);
-    $engname = trim($_POST['engname']);
-    $client_kind = trim($_POST['client_kind']);
-    $client_type = trim($_POST['client_type']);
-    $country = trim($_POST['country']);
-    $tel1 = trim($_POST['tel1']);
-    $tel2 = trim($_POST['tel2']);
-    $email = trim($_POST['email']);
-    $fax = trim($_POST['fax']);
-    $address = trim($_POST['address']);
+    $arname = trim($_POST['arname'] ?? '');
+    $engname = trim($_POST['engname'] ?? '');
+    $client_kind = trim($_POST['client_kind'] ?? '');
+    $client_type = trim($_POST['client_type'] ?? '');
+    $country = trim($_POST['country'] ?? '');
+    $tel1 = trim($_POST['tel1'] ?? '');
+    $tel2 = trim($_POST['tel2'] ?? '');
+    $email = trim($_POST['email'] ?? '');
+    $fax = trim($_POST['fax'] ?? '');
+    $address = trim($_POST['address'] ?? '');
 
     // --- Validation ---
     if (empty($arname) || empty($client_kind) || empty($client_type) || empty($tel1)) {
@@ -35,7 +38,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     } else {
         // --- Insert New Client ---
         $password = bin2hex(random_bytes(8));
-        $encrypted_password = openssl_encrypt($password, $cipher, $key, $options, $iv);
+        $encrypted_password = $aes->encrypt($password);
         $sql = "INSERT INTO client (arname, engname, client_kind, client_type, country, tel1, tel2, email, fax, address, password, perm) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)";
         $stmt = $conn->prepare($sql);
         $stmt->bind_param("sssssssssss", $arname, $engname, $client_kind, $client_type, $country, $tel1, $tel2, $email, $fax, $address, $encrypted_password);

--- a/editfile.php
+++ b/editfile.php
@@ -6,26 +6,26 @@
     include_once 'golden_pass.php';
     include_once 'secure_filesfunc.php';
     
-    $fidd = $_REQUEST['fid'];
+    $fidd = $_REQUEST['fid'] ?? null;
     if (isset($_REQUEST['save_file'])) {
         $fid = (int)filter_input(INPUT_POST, 'fidget', FILTER_SANITIZE_NUMBER_INT);
-        
+
+        // Ensure tracking variables are always defined
+        $flag2 = '0';
+        $action2 = "تم التعديل على الملف :<br>رقم الملف : $fid<br>";
+
         if(isset($_REQUEST['fclass_edit']) && $_REQUEST['fclass_edit'] !== ''){
             if($row_permcheck['cfiles_eperm'] == 1){
-                $flag2 = '0';
-                $action2 = "تم التعديل على الملف :<br>رقم الملف : $fid<br>";
-                
-                $stmtr = $conn->prepare("SELECT * FROM file WHERE file_id = ?"); 
-                $stmtr->bind_param("i", $fid); 
-                $stmtr->execute(); 
-                $resultr = $stmtr->get_result(); 
+
+                $stmtr = $conn->prepare("SELECT * FROM file WHERE file_id = ?");
+                $stmtr->bind_param("i", $fid);
+                $stmtr->execute();
+                $resultr = $stmtr->get_result();
                 $rowr = $resultr->fetch_assoc();
                 $stmtr->close();
-                
+
                 $type_edit = filter_input(INPUT_POST, "type_edit", FILTER_SANITIZE_FULL_SPECIAL_CHARS);
-                if(isset($rowr['file_type'])){
-                    $oldtype = isset($rowr['file_type']) ? safe_output($rowr['file_type']) : '';
-                }
+                $oldtype = isset($rowr['file_type']) ? safe_output($rowr['file_type']) : '';
                 if(isset($type_edit) && $type_edit !== $oldtype){
                     $flag2 = '1';
                     

--- a/employeeEdit.php
+++ b/employeeEdit.php
@@ -99,6 +99,8 @@
                                         
                                         <?php
                                             include_once 'AES256.php';
+                                            $encryption_key = getenv('ENCRYPTION_KEY') ?: 'default_key';
+                                            $aes = new AES256($encryption_key);
                                             $id = $_GET['id'];
                                             
                                             $query = "SELECT * FROM user WHERE id = '$id'";
@@ -136,7 +138,7 @@
                                                                             <?php
                                                                                 if(isset($row['password']) && $row['password'] !== ''){
                                                                                     $password = $row['password'];
-                                                                                    $decrypted_password = openssl_decrypt($password, $cipher, $key, $options, $iv);
+                                                                                    $decrypted_password = $aes->decrypt($password);
                                                                                 }
                                                                             ?>
                                                                             <input type="text" name="password" dir="rtl" value="<?php if(isset($row['password']) && $row['password'] !== ''){echo $decrypted_password;}?>" style="width:30%; text-align:center; color:#00F; font-weight:bold;"><br>
@@ -158,12 +160,12 @@
                                                                             <?php
                                                                                 if(isset($row['tel1']) && $row['tel1'] !== ''){
                                                                                     $tel1 = $row['tel1'];
-                                                                                    $decrypted_tel1 = openssl_decrypt($tel1, $cipher, $key, $options, $iv);
+                                                                                    $decrypted_tel1 = $aes->decrypt($tel1);
                                                                                 }
                                                                                 
                                                                                 if(isset($row['tel2']) && $row['tel2'] !== ''){
                                                                                     $tel2 = $row['tel2'];
-                                                                                    $decrypted_tel2 = openssl_decrypt($tel2, $cipher, $key, $options, $iv);
+                                                                                    $decrypted_tel2 = $aes->decrypt($tel2);
                                                                                 }
                                                                             ?>
                                                                             1 <input type="text" name="tel1" dir="rtl" value="<?php if(isset($row['tel1']) && $row['tel1'] !== ''){echo $decrypted_tel1;}?>" style="width:20%;"><br />
@@ -178,7 +180,7 @@
                                                                             <?php
                                                                             if(isset($row['email']) && $row['email'] !== ''){
                                                                                 $email = $row['email'];
-                                                                                $decrypted_email = openssl_decrypt($email, $cipher, $key, $options, $iv);
+                                                                                $decrypted_email = $aes->decrypt($email);
                                                                             }
                                                                             ?>
                                                                             <input type="text" name="email" dir="ltr" value="<?php if(isset($row['email']) && $row['email'] !== ''){echo $decrypted_email;}?>" style="width:50%;"><br>
@@ -466,7 +468,7 @@
                                                                             <?php
                                                                             if(isset($row['address']) && $row['address'] !== ''){
                                                                                 $address = $row['address'];
-                                                                                $decrypted_address = openssl_decrypt($address, $cipher, $key, $options, $iv);
+                                                                                $decrypted_address = $aes->decrypt($address);
                                                                             }
                                                                             ?>
                                                                             <textarea dir="rtl" wrap="physical" rows="2" style="width:98%" name="address"><?php if(isset($row['address']) && $row['address'] !== ''){echo $decrypted_address;}?></textarea>
@@ -479,7 +481,7 @@
                                                                             <?php
                                                                             if(isset($row['passport_no']) && $row['passport_no'] !== ''){
                                                                                 $passno = $row['passport_no'];
-                                                                                $decrypted_passno = openssl_decrypt($passno, $cipher, $key, $options, $iv);
+                                                                                $decrypted_passno = $aes->decrypt($passno);
                                                                             }
                                                                             ?>
                                                                             <input type="text" name="passport_no" dir="rtl" value="<?php if(isset($row['passport_no']) && $row['passport_no'] !== ''){echo $decrypted_passno;}?>" style="width:20%; text-align:center"> &nbsp;&nbsp;&nbsp; تاريخ الانتهاء : 
@@ -1431,12 +1433,15 @@
                                             <th ><?php if(isset($rowr['work_place']) && $rowr['work_place'] !== ''){ echo $rowr['work_place'];}?></th>
                                             <th ><?php if(isset($rowr['job_title']) && $rowr['job_title'] !== ''){ $psjt = $rowr['job_title']; $queryposti = "SELECT * FROM positions WHERE id='$psjt'"; $resultposti=mysqli_query($conn, $queryposti); if($resultposti->num_rows > 0){$rowposti=mysqli_fetch_array($resultposti); echo $rowposti['position_name'];}}?></th>
                                             <?php
-                                                include_once 'AES256.php';
+                                                if (!isset($aes)) {
+                                                    $encryption_key = getenv('ENCRYPTION_KEY') ?: 'default_key';
+                                                    $aes = new AES256($encryption_key);
+                                                }
                                                 $tel1 = $rowr['tel1'];
-                                                $decrypted_tel1 = openssl_decrypt($tel1, $cipher, $key, $options, $iv);
+                                                $decrypted_tel1 = $aes->decrypt($tel1);
 
                                                 $tel2 = $rowr['tel2'];
-                                                $decrypted_tel2 = openssl_decrypt($tel2, $cipher, $key, $options, $iv);
+                                                $decrypted_tel2 = $aes->decrypt($tel2);
                                             ?>
                                             <th ><?php if(isset($rowr['tel1']) && $rowr['tel1'] !== ''){ echo $decrypted_tel1;}?><br /></th>
                                             <th ><?php if(isset($rowr['name']) && $rowr['name'] !== ''){ echo $rowr['name'];}?></th>


### PR DESCRIPTION
## Summary
- guard editfile.php against missing request parameters and initialize change-tracking variables
- replace deprecated OpenSSL variable usage with AES256 helper in employee editing and client APIs
- sanitize client API POST fields to prevent undefined index notices

## Testing
- `php -l editfile.php`
- `php -l employeeEdit.php`
- `php -l api/client_add.php`
- `php -l api/saveClient.php`
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ae63d77ff8832bbdf1e71db46b6750