### PR TITLE
Annotate API globals and secure client creation

### DIFF
--- a/Accounts.php
+++ b/Accounts.php
@@ -3,6 +3,8 @@
     include_once 'login_check.php';
     include_once 'src/I18n.php';
 
+    /** @var mysqli $conn */
+
     $i18n = new I18n();
     $i18n->loadTranslations('translations/Accounts.yaml');
     // Use a prepared statement to securely fetch user permission data.

--- a/AddNotes.php
+++ b/AddNotes.php
@@ -3,6 +3,10 @@
     include_once 'login_check.php';
     include_once 'permissions_check.php';
 
+    /** @var mysqli $conn */
+    /** @var array $row_permcheck */
+    /** @var int $admin */
+
     // Get and validate the file number from the URL.
     $fno = filter_input(INPUT_GET, 'fno', FILTER_VALIDATE_INT);
     if (!$fno) {

--- a/a.php
+++ b/a.php
@@ -1,6 +1,9 @@
 <?php
     include_once 'connection.php';
     include_once 'login_check.php';
+
+    /** @var mysqli $conn */
+    $selectedDegree = $_POST['degree_id_sess'] ?? '';
 ?>
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">

--- a/ab.php
+++ b/ab.php
@@ -1,6 +1,8 @@
 <?php
     include_once 'connection.php';
     include_once 'login_check.php';
+
+    /** @var mysqli $conn */
     
     if(isset($_REQUEST['booked_todate']) && $_REQUEST['booked_todate'] !== ''){
         
@@ -89,8 +91,8 @@
         $newDateFormatted = $newDate->format('Y-m-d');
         
         $today = new DateTime();
-        $todatFormatted = $today->format('Y-m-d');
-        
+        $todayFormatted = $today->format('Y-m-d');
+
         $newTodayObject = new DateTime($todayFormatted);
         $newDateObject = new DateTime($newDateFormatted);
         $difference = $newTodayObject->diff($newDateObject);

--- a/addcase.php
+++ b/addcase.php
@@ -4,6 +4,11 @@
     include_once 'safe_output.php';
     include_once 'permissions_check.php';
     include_once 'AES256.php';
+
+    /** @var mysqli $conn */
+    /** @var array $row_permcheck */
+    /** @var array $row_details */
+    $row_details = $row_details ?? [];
 ?>
 <!DOCTYPE html>
 <html dir="rtl">

--- a/addfilefees.php
+++ b/addfilefees.php
@@ -2,6 +2,10 @@
     include_once 'connection.php';
     include_once 'login_check.php';
     include_once 'permissions_check.php';
+
+    /** @var mysqli $conn */
+    /** @var array $row_permcheck */
+    /** @var int $admin */
     
     $fid = filter_input(INPUT_POST, 'fid', FILTER_SANITIZE_NUMBER_INT);
     

--- a/addlog.php
+++ b/addlog.php
@@ -3,6 +3,8 @@
         $action = '';
     }
     $empid = $_SESSION['id'];
+
+    /** @var mysqli $conn */
     
     $stmtemp = $conn->prepare("SELECT * FROM user WHERE id=?");
     $stmtemp->bind_param("i", $empid);

--- a/api/addPosition.php
+++ b/api/addPosition.php
@@ -3,6 +3,8 @@ header('Content-Type: application/json');
 include_once '../connection.php';
 include_once '../login_check.php';
 
+/** @var mysqli $conn */
+
 $response = ['status' => 'error', 'message' => 'An unknown error occurred.'];
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['position_name'])) {
@@ -34,3 +36,4 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['position_name'])) {
 
 $conn->close();
 echo json_encode($response);
+

--- a/api/client_add.php
+++ b/api/client_add.php
@@ -5,7 +5,15 @@ include_once '../login_check.php';
 include_once '../permissions_check.php';
 include_once '../AES256.php';
 
-$encryption_key = getenv('ENCRYPTION_KEY') ?: 'default_key';
+/** @var mysqli $conn */
+/** @var array $row_permcheck */
+
+$encryption_key = getenv('ENCRYPTION_KEY') ?: '';
+if ($encryption_key === '') {
+    $response = ['status' => 'error', 'message' => 'Encryption key not configured.'];
+    echo json_encode($response);
+    exit();
+}
 $aes = new AES256($encryption_key);
 
 $response = ['status' => 'error', 'message' => 'An unknown error occurred.'];
@@ -57,3 +65,4 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
 $conn->close();
 echo json_encode($response);
+

--- a/api/client_edit.php
+++ b/api/client_edit.php
@@ -4,6 +4,9 @@ include_once '../connection.php';
 include_once '../login_check.php';
 include_once '../permissions_check.php';
 
+/** @var mysqli $conn */
+/** @var array $row_permcheck */
+
 $response = ['status' => 'error', 'message' => 'An unknown error occurred.'];
 
 if ($row_permcheck['clients_eperm'] != 1) {
@@ -58,3 +61,4 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['client_id'])) {
 
 echo json_encode($response);
 $conn->close();
+

--- a/api/client_get.php
+++ b/api/client_get.php
@@ -4,6 +4,9 @@ include_once '../connection.php';
 include_once '../login_check.php';
 include_once '../permissions_check.php';
 
+/** @var mysqli $conn */
+/** @var array $row_permcheck */
+
 $response = ['status' => 'error', 'message' => 'An unknown error occurred.'];
 
 if ($row_permcheck['clients_rperm'] != 1) {
@@ -38,3 +41,4 @@ if (isset($_GET['id'])) {
 
 $conn->close();
 echo json_encode($response);
+

--- a/api/client_update.php
+++ b/api/client_update.php
@@ -4,6 +4,9 @@ include_once '../connection.php';
 include_once '../login_check.php';
 include_once '../permissions_check.php';
 
+/** @var mysqli $conn */
+/** @var array $row_permcheck */
+
 $response = ['status' => 'error', 'message' => 'An unknown error occurred.'];
 
 if ($row_permcheck['clients_eperm'] != 1) {
@@ -51,3 +54,4 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['client_id'])) {
 
 $conn->close();
 echo json_encode($response);
+

--- a/api/getExpense.php
+++ b/api/getExpense.php
@@ -3,6 +3,8 @@ header('Content-Type: application/json');
 include_once '../connection.php';
 include_once '../login_check.php';
 
+/** @var mysqli $conn */
+
 $response = ['status' => 'error', 'message' => 'Invalid request.'];
 
 if (isset($_GET['id'])) {
@@ -26,3 +28,4 @@ if (isset($_GET['id'])) {
 }
 
 echo json_encode($response);
+

--- a/api/getRevenue.php
+++ b/api/getRevenue.php
@@ -3,6 +3,8 @@ header('Content-Type: application/json');
 include_once '../connection.php';
 include_once '../login_check.php';
 
+/** @var mysqli $conn */
+
 $response = ['status' => 'error', 'message' => 'Invalid request.'];
 
 if (isset($_GET['id'])) {
@@ -26,3 +28,4 @@ if (isset($_GET['id'])) {
 }
 
 echo json_encode($response);
+

--- a/api/saveClient.php
+++ b/api/saveClient.php
@@ -4,7 +4,14 @@ include_once '../connection.php';
 include_once '../login_check.php';
 include_once '../AES256.php';
 
-$encryption_key = getenv('ENCRYPTION_KEY') ?: 'default_key';
+/** @var mysqli $conn */
+
+$encryption_key = getenv('ENCRYPTION_KEY') ?: '';
+if ($encryption_key === '') {
+    $response = ['status' => 'error', 'message' => 'Encryption key not configured.'];
+    echo json_encode($response);
+    exit();
+}
 $aes = new AES256($encryption_key);
 
 $response = ['status' => 'error', 'message' => 'Invalid request method.'];
@@ -58,3 +65,4 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 }
 
 echo json_encode($response);
+

--- a/api/saveExpense.php
+++ b/api/saveExpense.php
@@ -4,6 +4,9 @@ include_once '../connection.php';
 include_once '../login_check.php';
 include_once '../permissions_check.php'; // Important for security
 
+/** @var mysqli $conn */
+/** @var array $row_permcheck */
+
 $response = ['status' => 'error', 'message' => 'An unknown error occurred.'];
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
@@ -50,3 +53,4 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 }
 
 echo json_encode($response);
+

--- a/api/saveInvoice.php
+++ b/api/saveInvoice.php
@@ -4,6 +4,9 @@ include_once '../connection.php';
 include_once '../login_check.php';
 include_once '../permissions_check.php';
 
+/** @var mysqli $conn */
+/** @var array $row_permcheck */
+
 $response = ['status' => 'error', 'message' => 'An unknown error occurred.'];
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
@@ -51,3 +54,4 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 }
 
 echo json_encode($response);
+

--- a/api/saveRevenue.php
+++ b/api/saveRevenue.php
@@ -4,6 +4,9 @@ include_once '../connection.php';
 include_once '../login_check.php';
 include_once '../permissions_check.php';
 
+/** @var mysqli $conn */
+/** @var array $row_permcheck */
+
 $response = ['status' => 'error', 'message' => 'An unknown error occurred.'];
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
@@ -50,3 +53,4 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 }
 
 echo json_encode($response);
+

--- a/controllers/clients.php
+++ b/controllers/clients.php
@@ -12,6 +12,8 @@ require_once __DIR__ . '/../bootstrap.php';
 require_once __DIR__ . '/../permissions_check.php';
 require_once __DIR__ . '/../safe_output.php';
 
+/** @var array $row_permcheck */
+
 $pageTitle = __('clients');
 
 // 2. HEADER

--- a/editfile.php
+++ b/editfile.php
@@ -2618,7 +2618,7 @@
         }
         
         $fidd = $fid2;
-    } else if(isset($_REQUEST['edit_document'])){
+    } else if(filter_has_var(INPUT_POST, 'edit_document')){
         if($row_permcheck['note_eperm'] == 1){
             $cdoid = filter_input(INPUT_POST, 'cdoid', FILTER_SANITIZE_NUMBER_INT);
             

--- a/partials/_file_attachments.php
+++ b/partials/_file_attachments.php
@@ -1,5 +1,9 @@
 <?php
 // FILE: partials/_file_attachments.php
+
+/** @var array $data */
+/** @var array $row_permcheck */
+/** @var int|string $fileId */
 ?>
 
 <section class="form-section">

--- a/partials/_file_degrees.php
+++ b/partials/_file_degrees.php
@@ -1,5 +1,9 @@
 <?php
 // FILE: partials/_file_degrees.php
+
+/** @var array $data */
+/** @var array $row_permcheck */
+/** @var int|string $fileId */
 ?>
 
 <section class="form-section">

--- a/partials/_file_details.php
+++ b/partials/_file_details.php
@@ -1,5 +1,10 @@
 <?php
 // FILE: partials/_file_details.php
+
+/** @var array $data */
+/** @var array $row_permcheck */
+/** @var array $fileDetails */
+/** @var int|string $fileId */
 ?>
 
 <section class="form-section">

--- a/partials/_file_legal_entities.php
+++ b/partials/_file_legal_entities.php
@@ -1,5 +1,8 @@
 <?php
 // FILE: partials/_file_legal_entities.php
+
+/** @var array $data */
+/** @var array $fileDetails */
 ?>
 
 <section class="form-section">

--- a/partials/_file_parties.php
+++ b/partials/_file_parties.php
@@ -1,5 +1,8 @@
 <?php
 // FILE: partials/_file_parties.php
+
+/** @var array $data */
+/** @var array $fileDetails */
 ?>
 
 <section class="form-section">

--- a/partials/_file_sessions.php
+++ b/partials/_file_sessions.php
@@ -1,5 +1,9 @@
 <?php
 // FILE: partials/_file_sessions.php
+
+/** @var array $data */
+/** @var array $row_permcheck */
+/** @var int|string $fileId */
 ?>
 
 <section class="form-section">

--- a/partials/_file_staff.php
+++ b/partials/_file_staff.php
@@ -1,5 +1,8 @@
 <?php
 // FILE: partials/_file_staff.php
+
+/** @var array $data */
+/** @var array $fileDetails */
 ?>
 
 <section class="form-section">

--- a/partials/_file_tasks.php
+++ b/partials/_file_tasks.php
@@ -1,5 +1,9 @@
 <?php
 // FILE: partials/_file_tasks.php
+
+/** @var array $data */
+/** @var array $row_permcheck */
+/** @var int|string $fileId */
 ?>
 
 <section class="form-section">

--- a/views/clients.view.php
+++ b/views/clients.view.php
@@ -2,6 +2,10 @@
 /**
  * View file for displaying the clients list.
  */
+
+/** @var array $clients */
+/** @var array $row_permcheck */
+/** @var string $type */
 ?>
 
 <div class="container-fluid mt-4">


### PR DESCRIPTION
## Summary
- replace insecure use of `$_REQUEST` with `filter_has_var` for `edit_document` updates
- infer parameter types in `Database` helper and handle bind errors
- document expected database and permission globals across API endpoints to fix undefined-variable warnings
- enforce configured AES-256 encryption key when creating clients
- document expected globals in controllers, views, and case file partials
- initialize missing variables in session booking scripts

## Testing
- `php -l api/addClient.php api/addPosition.php api/client_add.php api/client_edit.php api/client_get.php api/client_update.php api/getExpense.php api/getRevenue.php api/saveClient.php api/saveExpense.php api/saveInvoice.php api/saveRevenue.php`
- `php -l Accounts.php AddNotes.php a.php ab.php addcase.php addfilefees.php addlog.php controllers/clients.php partials/_file_attachments.php partials/_file_degrees.php partials/_file_details.php partials/_file_legal_entities.php partials/_file_parties.php partials/_file_sessions.php partials/_file_staff.php partials/_file_tasks.php views/clients.view.php`
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ae6ce2a080832bb8813103c2baaae7