### PR TITLE
Ensure required PHP extensions and PSR-4 namespaces

### DIFF
--- a/api/client_edit.php
+++ b/api/client_edit.php
@@ -32,12 +32,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['client_id'])) {
     if ($stmt) {
         $stmt->bind_param(
             "ssssssssssi",
-            $_POST['arname'],
+            $arname,
             $_POST['engname'],
             $_POST['client_kind'],
             $_POST['client_type'],
             $_POST['country'],
-            $_POST['tel1'],
+            $tel1,
             $_POST['tel2'],
             $_POST['email'],
             $_POST['fax'],

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,9 @@
         "symfony/translation": "^7.3",
         "symfony/yaml": "^7.3",
         "ext-curl": "*",
-        "ext-mysqli": "*"
+        "ext-json": "*",
+        "ext-mysqli": "*",
+        "ext-openssl": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ff05c5ee3cd7323ceee02521541c1743",
+    "content-hash": "273d9c87c243f2cd478eda27a9112a2d",
     "packages": [
         {
             "name": "composer/pcre",
@@ -3678,7 +3678,9 @@
     "platform": {
         "php": "^7.4 || ^8.0",
         "ext-curl": "*",
-        "ext-mysqli": "*"
+        "ext-json": "*",
+        "ext-mysqli": "*",
+        "ext-openssl": "*"
     },
     "platform-dev": {},
     "plugin-api-version": "2.6.0"

--- a/src/Database.php
+++ b/src/Database.php
@@ -1,5 +1,9 @@
 <?php
 
+namespace App;
+
+use mysqli;
+
 class Database {
     private static ?mysqli $connection = null;
 

--- a/src/Router.php
+++ b/src/Router.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace App;
+
 class Router {
     protected array $routes = [];
 


### PR DESCRIPTION
## Summary
- declare `ext-json` and `ext-openssl` in composer requirements
- add App namespace to Database and Router classes
- use sanitized inputs when updating client records

## Testing
- `composer update --lock`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68ae7eec13d4832ba831c97ca51aed4d