### PR TITLE
Switch project to Podman Compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ DB_USER=root
 DB_PASS=password
 DB_NAME=my_database
 
-# For Docker, this should match the 'password' in the 'db' service in docker-compose.yml
+# For Podman, this should match the 'password' in the 'db' service in podman-compose.yml
 MYSQL_ROOT_PASSWORD=password
 
 # Email API (Sendinblue/Brevo)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ To test the service locally, run:
 php -S localhost:3000 index.php
 ```
 
+To start the full containerized stack, use Podman Compose:
+
+```sh
+podman compose up -d
+```
+
+When finished, stop the services with:
+
+```sh
+podman compose down
+```
+
 ## Configuration
 
 Copy `.env.example` to `.env` and provide values for the required environment variables. To enable email features, set `SENDINBLUE_API_KEY` with your Brevo (Sendinblue) API key.

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -3,29 +3,35 @@ version: '3.8'
 services:
   web:
     image: nginx:latest
+    container_name: mbhtest_web
     ports:
       - "8080:80"
     volumes:
-      - .:/var/www/html
-      - ./docker/nginx/default.conf:/etc/nginx/conf.d/default.conf
+      - .:/var/www/html:Z
+      - ./docker/nginx/default.conf:/etc/nginx/conf.d/default.conf:Z
     depends_on:
       - php
+    networks:
+      - mbh_net
 
   php:
     build:
       context: .
       dockerfile: Dockerfile
+    container_name: mbhtest_php
     volumes:
-      - .:/var/www/html
+      - .:/var/www/html:Z
     depends_on:
       - db
-      - cache  # Depends on the new cache service
+      - cache
     environment:
-      # Pass the cache host to your PHP app
       MEMCACHED_HOST: cache
+    networks:
+      - mbh_net
 
   db:
     image: mysql:8.0
+    container_name: mbhtest_db
     environment:
       MYSQL_ROOT_PASSWORD: password
       MYSQL_DATABASE: mbhtest
@@ -33,8 +39,22 @@ services:
       MYSQL_PASSWORD: password
     ports:
       - "3306:3306"
+    volumes:
+      - db_data:/var/lib/mysql
+    networks:
+      - mbh_net
 
   cache:
     image: memcached:latest
+    container_name: mbhtest_cache
     ports:
       - "11211:11211"
+    networks:
+      - mbh_net
+
+volumes:
+  db_data:
+
+networks:
+  mbh_net:
+    driver: bridge

--- a/temp_countries.sql
+++ b/temp_countries.sql
@@ -1,4 +1,4 @@
-docker compose exec -T db mysql -u mbh -p'#yuCyTJ!FI=K' mbhdb -e "CREATE TABLE countries (id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(255) NOT NULL UNIQUE) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+podman compose exec -T db mysql -u mbh -p'#yuCyTJ!FI=K' mbhdb -e "CREATE TABLE countries (id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(255) NOT NULL UNIQUE) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
 INSERT INTO `countries` (`name`) VALUES
 ('Afghanistan'), ('Albania'), ('Algeria'), ('Andorra'), ('Angola'), ('Antigua and Barbuda'), ('Argentina'), ('Armenia'), ('Australia'), ('Austria'),
 ('Azerbaijan'), ('Bahamas'), ('Bahrain'), ('Bangladesh'), ('Barbados'), ('Belarus'), ('Belgium'), ('Belize'), ('Benin'), ('Bhutan'),

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -7,7 +7,7 @@ use GuzzleHttp\Exception\ConnectException;
 class IntegrationTest extends TestCase
 {
     protected static $httpClient;
-    protected static $baseUrl = 'http://localhost:8080'; // Updated to match docker-compose.yml
+    protected static $baseUrl = 'http://localhost:8080'; // Updated to match podman-compose.yml
     protected static $skip = false;
 
     public static function setUpBeforeClass(): void


### PR DESCRIPTION
## Summary
- Replace Docker Compose setup with Podman Compose configuration
- Update environment and integration test comments for Podman
- Refresh docs and SQL script with `podman compose` commands

## Testing
- `podman compose -f podman-compose.yml config`
- `composer install`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68ae847016b0832ba0081eca1ae630ef