### PR TITLE
Parameterize integration test base URL

### DIFF
--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -7,11 +7,13 @@ use GuzzleHttp\Exception\ConnectException;
 class IntegrationTest extends TestCase
 {
     protected static $httpClient;
-    protected static $baseUrl = 'http://localhost:8080'; // Updated to match docker-compose.yml
+    protected static $baseUrl = 'http://localhost:8080'; // matches containerized environment on port 8080
     protected static $skip = false;
 
     public static function setUpBeforeClass(): void
     {
+        self::$baseUrl = getenv('BASE_URL') ?: self::$baseUrl;
+
         self::$httpClient = new Client([
             'base_uri' => self::$baseUrl,
             'http_errors' => false, // We want to handle HTTP errors manually in tests


### PR DESCRIPTION
## Summary
- let integration tests read BASE_URL env var
- clarify comment that default URL matches container port 8080

## Testing
- `vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68ae847d7b10832b93fea317f4f45fd0