### PR TITLE
docs: add podman usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,42 @@ php -S localhost:3000 index.php
 
 Copy `.env.example` to `.env` and provide values for the required environment variables. To enable email features, set `SENDINBLUE_API_KEY` with your Brevo (Sendinblue) API key.
 
+## Podman
+
+The project can also be built and run inside a container using [Podman](https://podman.io/).
+
+### Environment setup
+
+1. Copy the example environment file and adjust values as needed:
+
+   ```sh
+   cp .env.example .env
+   # edit .env to suit your local environment
+   ```
+
+2. Podman commands can load these variables with `--env-file .env` or through `podman compose`, which reads the `.env` file automatically when a `compose.yml` or `docker-compose.yml` is present.
+
+### Build and run
+
+Build the container image and run it directly:
+
+```sh
+podman build -t php-api .
+podman run --rm -p 8080:8080 --env-file .env php-api
+```
+
+### Using Podman Compose
+
+If you have a `compose.yml` (or `docker-compose.yml`) file, Podman can manage the service with familiar compose commands:
+
+```sh
+podman compose up --build -d    # start containers
+podman compose logs -f          # view logs
+podman compose down             # stop and remove containers
+```
+
+These commands are helpful during development for rebuilding images, checking logs, and tearing down containers when finished.
+
 ## Testing
 
 Install Composer dependencies and run the PHPUnit test suite:


### PR DESCRIPTION
## Summary
- document how to run the project with Podman
- include common compose commands and env setup steps

## Testing
- `composer install`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68aea55f6b4c832bbd470dc250e3d557