### PR TITLE
Add docker compose for development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,11 +3,12 @@
 
 # Database Credentials
 DB_HOST=db
+DB_PORT=3306
 DB_USER=root
 DB_PASS=password
 DB_NAME=my_database
 
-# For Docker, this should match the 'password' in the 'db' service in docker-compose.yml
+# This must match the MYSQL_ROOT_PASSWORD used by the 'db' service in docker-compose.yml
 MYSQL_ROOT_PASSWORD=password
 
 # Email API (Sendinblue/Brevo)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+version: '3.8'
+
+services:
+  app:
+    image: php:8.1-apache
+    ports:
+      - "8080:80"
+    volumes:
+      - ./:/var/www/html
+    depends_on:
+      - db
+    env_file:
+      - .env
+
+  db:
+    image: mysql:8.0
+    restart: always
+    environment:
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${DB_NAME}
+      MYSQL_USER: ${DB_USER}
+      MYSQL_PASSWORD: ${DB_PASS}
+    volumes:
+      - db_data:/var/lib/mysql
+    ports:
+      - "3306:3306"
+
+  phpmyadmin:
+    image: phpmyadmin:latest
+    depends_on:
+      - db
+    ports:
+      - "8081:80"
+    environment:
+      PMA_HOST: db
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
+
+volumes:
+  db_data:


### PR DESCRIPTION
## Summary
- add docker compose file for PHP app, MySQL, and phpMyAdmin
- align .env.example with compose service settings

## Testing
- `composer install`
- `vendor/bin/phpunit 2>&1`


------
https://chatgpt.com/codex/tasks/task_e_68aea55ea4a0832bb81fc7593d033178