### PR TITLE
Add one-year limited warranty

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 MBH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED WITH A LIMITED ONE-YEAR WARRANTY.
+THIS WARRANTY COVERS DEFECTS IN MATERIALS AND WORKMANSHIP
+FOR ONE YEAR FROM THE DATE YOU FIRST OBTAIN THE SOFTWARE.
+THE WARRANTY DOES NOT APPLY TO MISUSE, MODIFICATIONS, OR
+EXTERNAL CAUSES. LIABILITY IS LIMITED TO REPAIR,
+REPLACEMENT, OR REFUND OF THE PURCHASE PRICE.
+AFTER ONE YEAR, THE SOFTWARE IS PROVIDED "AS IS" WITHOUT FURTHER WARRANTIES.
+

--- a/README.md
+++ b/README.md
@@ -70,3 +70,7 @@ composer config -g github-oauth.github.com your_token
 If you cannot provide credentials, mirror or replace those private dependencies with public equivalents so `composer install` works without special access.
 
 The tests use mocked database connections to avoid touching production data.
+
+## License
+
+This project is licensed under the [MIT License](LICENSE). The license includes a limited one-year warranty covering defects in materials and workmanship. Liability is limited to repair, replacement, or refund within one year of obtaining the software; after that period, the software is provided "as is" without further warranties.


### PR DESCRIPTION
## Summary
- add a one-year limited warranty clause to the project license
- document warranty terms in the README license section

## Testing
- `composer install`
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68afde0ac438832b89e7c03dff03e2ad