### PR TITLE
Add limited one-year warranty

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+MIT License
+
+Copyright (c) 2024 MBH
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+The Software is provided with a limited one-year warranty beginning on the date of delivery.
+This warranty covers defects in materials and workmanship under normal use.
+During the warranty period, the authors will, at their option, repair or replace
+any portion of the Software that proves defective, provided the Software has not
+been modified or misused. This warranty does not cover incidental or consequential damages.
+The authors' total liability under this warranty is limited to the amount paid for the Software.
+Except as expressly stated herein, no other warranties, express or implied, are provided.

--- a/README.md
+++ b/README.md
@@ -70,3 +70,7 @@ composer config -g github-oauth.github.com your_token
 If you cannot provide credentials, mirror or replace those private dependencies with public equivalents so `composer install` works without special access.
 
 The tests use mocked database connections to avoid touching production data.
+
+## License
+
+This project is licensed under the MIT License with a limited one-year warranty. The warranty covers defects in materials and workmanship for one year from the date of delivery. Remedies are limited to repair or replacement, and liability is capped at the amount paid for the Software. See [LICENSE](LICENSE) for full terms.


### PR DESCRIPTION
## Summary
- Add MIT license with limited one-year warranty and liability cap
- Document warranty conditions in README

## Testing
- `php composer.phar install --no-interaction --no-progress`
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68afdd377744832babeef0c7acba5cc9